### PR TITLE
Better evaluation for functions and objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Very simple [math.js](https://mathjs.org/) editor using [CodeJar](https://medv.io/codejar/) and
 [highlight.js](https://highlightjs.org/).
 
+This is a fork from felipec/math-notepad trying to show only important outputs and showing from which input it comes from. Also it shows the cases where the outputs show multiple lines.
 
 You can try it online at https://dvd101x.github.io/math-notepad/
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Very simple [math.js](https://mathjs.org/) editor using [CodeJar](https://medv.i
 [highlight.js](https://highlightjs.org/).
 
 
-You can try it online at https://felipec.github.io/math-notepad/.
+You can try it online at https://dvd101x.github.io/math-notepad/
 
 This is a simplified version of [Engineering-Solver](https://github.com/dvd101x/Engineering-Solver)
 plus syntax highlighting.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Very simple [math.js](https://mathjs.org/) editor using [CodeJar](https://medv.io/codejar/) and
 [highlight.js](https://highlightjs.org/).
 
-This is a fork from felipec/math-notepad trying to show only important outputs and showing from which input it comes from. Also it shows the cases where the outputs show multiple lines.
+This is a fork from [felipec/math-notepad](https://github.com/felipec/math-notepad) trying to show only important outputs and showing from which input it comes from. Also it shows the cases where the outputs show multiple lines.
 
 You can try it online at https://dvd101x.github.io/math-notepad/
 

--- a/script.js
+++ b/script.js
@@ -6,15 +6,17 @@ function doMath(input) {
     let output = [];
     const inputs = input.split('\n');
     parser.clear();
-    inputs.forEach((input, I) => {
+    inputs.forEach((input, inputIndex) => {
       try {
         output_line = parser.evaluate(input);
       }
       catch (e) {
         output_line = e;
       }
+      // Checks for unwanted outputs like [], function() ..., null, etc.
       if (output_line && output_line.toString() != "[]" && typeof (output_line) != "function" && output_line.toString() != "[object Object]") {
-        output.push((I + 1) + ":" + output_line.toString().split("\n").map(l => "\t" + l).join("\n"))
+        // Formats the output to show from which line it comes from and accounts for multiple line outputs
+        output.push((inputIndex + 1) + ":" + parser.format(output_line,14).split("\n").map(l => "\t" + l).join("\n"))
       }
     })
     results.updateCode(output.join("\n"))

--- a/script.js
+++ b/script.js
@@ -1,26 +1,24 @@
 const wait = 100;
 
+const parser = self.math.parser()
 function doMath(input) {
-  let output = [];
-  let scope = {};
-
-  for (const line of input.split('\n')) {
-    let output_line = '';
-    if (line) {
-      if (line.startsWith('#')) {
-        output_line = line;
-      } else {
-        try {
-          output_line = math.evaluate(line, scope);
-        } catch(e) {
-          output_line = e;
-        }
+  if (input) {
+    let output = [];
+    const inputs = input.split('\n');
+    parser.clear();
+    inputs.forEach((input, I) => {
+      try {
+        output_line = parser.evaluate(input);
       }
-    }
-    output.push(output_line.toString());
+      catch (e) {
+        output_line = e;
+      }
+      if (output_line && output_line.toString() != "[]" && typeof (output_line) != "function" && output_line.toString() != "[object Object]") {
+        output.push((I + 1) + ":" + output_line.toString().split("\n").map(l => "\t" + l).join("\n"))
+      }
+    })
+    results.updateCode(output.join("\n"))
   }
-
-  results.updateCode(output.join('\n'));
 }
 
 var timer;

--- a/script.js
+++ b/script.js
@@ -1,26 +1,26 @@
 const wait = 100;
 
-const parser = self.math.parser()
 function doMath(input) {
-  if (input) {
-    let output = [];
-    const inputs = input.split('\n');
-    parser.clear();
-    inputs.forEach((input, inputIndex) => {
-      try {
-        output_line = parser.evaluate(input);
+  let output = [];
+  let scope = {};
+
+  for (const line of input.split('\n')) {
+    let output_line = '';
+    if (line) {
+      if (line.startsWith('#')) {
+        output_line = line;
+      } else {
+        try {
+          output_line = math.format(math.evaluate(line, scope),14);
+        } catch(e) {
+          output_line = e;
+        }
       }
-      catch (e) {
-        output_line = e;
-      }
-      // Checks for unwanted outputs like [], function() ..., null, etc.
-      if (output_line && output_line.toString() != "[]" && typeof (output_line) != "function" && output_line.toString() != "[object Object]") {
-        // Formats the output to show from which line it comes from and accounts for multiple line outputs
-        output.push((inputIndex + 1) + ":" + math.format(output_line,14).split("\n").map(l => "\t" + l).join("\n"))
-      }
-    })
-    results.updateCode(output.join("\n"))
+    }
+    output.push(output_line.toString());
   }
+
+  results.updateCode(output.join('\n'));
 }
 
 var timer;

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ function doMath(input) {
       // Checks for unwanted outputs like [], function() ..., null, etc.
       if (output_line && output_line.toString() != "[]" && typeof (output_line) != "function" && output_line.toString() != "[object Object]") {
         // Formats the output to show from which line it comes from and accounts for multiple line outputs
-        output.push((inputIndex + 1) + ":" + parser.format(output_line,14).split("\n").map(l => "\t" + l).join("\n"))
+        output.push((inputIndex + 1) + ":" + math.format(output_line,14).split("\n").map(l => "\t" + l).join("\n"))
       }
     })
     results.updateCode(output.join("\n"))


### PR DESCRIPTION
Better evaluation for functions and objects. Hides some of the floating point error more evident on `sin(30 deg)`

```
f(x,y) = x+y
f(2,3)
car = {mass: 10 kg, color: "blue"}
sin(30 deg)
```
Returns:
```
f(x, y)
5
{"mass": 10 kg, "color": "blue"}
0.5
```
Instead of:
```
function e(t,r){return(arguments.length===z&&m(t)&&b(r)?O:arguments.length===R&&d(t)&&w(r)?_:arguments.length===q&&y(t)&&N(r)?C:arguments.length===B&&g(t)&&M(r)?T:arguments.length===D&&v(t)&&E(r)?I:arguments.length===j&&x(t)&&S(r)?k:a).apply(e,arguments)}
5
[object Object]
0.49999999999999994
```